### PR TITLE
Move .env example from Registrering

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,0 +1,12 @@
+DJANGO_DEBUG=False
+# You must configure the DJANGO_SECRET_KEY with
+# a long, unique string of random characters.
+#DJANGO_SECRET_KEY=""
+DJANGO_HOSTS=example.org,www.example.org
+DJANGO_DATABASE_ENGINE=django.db.backends.postgresql
+DJANGO_DATABASE_HOST=database
+#DJANGO_DATABASE_PORT=5432
+
+POSTGRES_DB=EventAccess
+POSTGRES_USER=EventAccess
+POSTGRES_PASSWORD="Supersecret password CHANGEME!"


### PR DESCRIPTION
Small mistake, need the example env to be located outside registration, now that compose file is moved out aswell.